### PR TITLE
Fix Illegal access error by QtiPhoneSwitcher.java

### DIFF
--- a/src/java/com/android/internal/telephony/PhoneSwitcher.java
+++ b/src/java/com/android/internal/telephony/PhoneSwitcher.java
@@ -981,7 +981,7 @@ public class PhoneSwitcher extends Handler {
         return phoneId;
     }
 
-    private int getSubIdFromNetworkSpecifier(NetworkSpecifier specifier) {
+    protected int getSubIdFromNetworkSpecifier(NetworkSpecifier specifier) {
         if (specifier == null) {
             return DEFAULT_SUBSCRIPTION_ID;
         }


### PR DESCRIPTION
qti-telephony-common.jar patched for compatibility with r9 needs this
E AndroidRuntime: java.lang.IllegalAccessError: Method 'int com.android.internal.telephony.PhoneSwitcher.getSubIdFromNetworkSpecifier(android.net.NetworkSpecifier)' is inaccessible to class 'com.qualcomm.qti.internal.telephony.QtiPhoneSwitcher' (declaration of 'com.qualcomm.qti.internal.telephony.QtiPhoneSwitcher' appears in /product/framework/qti-telephony-common.jar)